### PR TITLE
feat: add chain providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > React component to organize and flatten providers.
 
-[![NPM](https://img.shields.io/npm/v/react-flat-providers.svg)](https://www.npmjs.com/package/react-flat-providers) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+[![NPM](https://img.shields.io/npm/v/react-flat-providers.svg)](https://www.npmjs.com/package/react-flat-providers)
 
 ## Install
 
@@ -72,7 +72,7 @@ A full working example can be found following the link below:
 
 ```tsx
 /**
- * Please check /example/src/index.tsx and imported providers
+ * Please check https://stackblitz.com/edit/react-flat-providers-example?file=src/index.tsx
  * to see how to use FlatProviders more detailed.
  * */
 
@@ -91,13 +91,30 @@ A full working example can be found following the link below:
 </FlatProviders>
 ```
 
-```ts
-// A Provider can be anything that exposes a Context
-type Provider = FunctionComponent<any> | ComponentClass<any> | typeof Component;
+### To enforce type safety, we encourage usage of the next helpers
 
-// Passed Providers must be an Array that have as values:
-// Provider or an Array with Provider and its properties as Object
-type Providers = Array<Provider | [Provider, Record<string, unknown>]>;
+```ts
+<FlatProviders
+  providers={[
+    // import `makeProvider` to infer props type from frovider
+    makeProvider(BooleanProvider, { initialValue: true }),
+  ]}
+>
+  <App />
+</FlatProviders>
+```
+
+```ts
+// to have only one import and lower level of indentation
+// this hook can be used to build flat chained version
+const FlatChainedProviders = useChainProviders()
+  .add(NumberProvider)
+  .add(BooleanProvider, { initialValue: true })
+  .make();
+
+<FlatChainedProviders>
+  <App />
+</FlatChainedProviders>
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -18,28 +18,41 @@ Just use the `FlatProviders`-Component and pass it an Array of your Providers an
 import { FlatProviders } from 'react-flat-providers';
 // ...
 
-    <FlatProviders
-      providers={[
-        ProviderWithoutProps,
-        [ProviderWithProps, { providerProps: 'propsValue' }],
-      ]}
-    >
-      <App />
-    </FlatProviders>
+<FlatProviders
+  providers={[
+    ProviderWithoutProps,
+    [ProviderWithProps, { providerProps: 'propsValue' }],
+  ]}
+>
+  <App />
+</FlatProviders>
 ```
 
 ### Type-Safe Props
 
-If you are using `TypeScript` and you want type-safety for your Providers' props, you can use the provided `makeProvider` function:
+If you are using `TypeScript` and you want type-safety for your Providers' props, you can use the provided `makeProvider` function or `useChainProviders` hook:
 
 ```tsx
 import { FlatProviders, makeProvider } from 'react-flat-providers';
 
-    <FlatProviders
-      providers={[
-        makeProvider(ProviderWithProps, { providerProps: 'typeSafe'}),
-      ]}
-    >
+<FlatProviders
+  providers={[
+    makeProvider(ProviderWithProps, { providerProps: 'typeSafe'}),
+  ]}
+>
+```
+
+```tsx
+import { useChainProviders } from 'react-flat-providers';
+
+const FlatChainedProviders = useChainProviders()
+  .add(NumberProvider)
+  .add(BooleanProvider, { initialValue: true })
+  .make();
+
+<FlatChainedProviders>
+  <App />
+</FlatChainedProviders>
 ```
 
 ### Example
@@ -68,54 +81,6 @@ A full working example can be found following the link below:
 </NumberProvider>
 ```
 
-## Solution
-
-```tsx
-/**
- * Please check https://stackblitz.com/edit/react-flat-providers-example?file=src/index.tsx
- * to see how to use FlatProviders more detailed.
- * */
-
-<FlatProviders
-  providers={[
-    // Can pass directly as FunctionComponent
-    NumberProvider,
-    // Can pass as Pair of Component and Object with parameters
-    [BooleanProvider, { initialValue: true }],
-    // Even as Pair of Context.Provider and Object with key 'value'
-    // Compatible with Redux-Toolkit with Object with key 'store'
-    [StringContext.Provider, { value: 'Hello world!' }],
-  ]}
->
-  <App />
-</FlatProviders>
-```
-
-### To enforce type safety, we encourage usage of the next helpers
-
-```ts
-<FlatProviders
-  providers={[
-    // import `makeProvider` to infer props type from frovider
-    makeProvider(BooleanProvider, { initialValue: true }),
-  ]}
->
-  <App />
-</FlatProviders>
-```
-
-```ts
-// to have only one import and lower level of indentation
-// this hook can be used to build flat chained version
-const FlatChainedProviders = useChainProviders()
-  .add(NumberProvider)
-  .add(BooleanProvider, { initialValue: true })
-  .make();
-
-<FlatChainedProviders>
-  <App />
-</FlatChainedProviders>
-```
 
 ## License
 

--- a/src/core/flat-providers.tsx
+++ b/src/core/flat-providers.tsx
@@ -1,0 +1,22 @@
+import React, { PropsWithChildren, ReactElement } from 'react';
+import { nestProviders } from '../aggregators/nest-providers';
+import { unwrapTupleProvider } from '../aggregators/unwrap-tuple-providers';
+import { ProviderComponent, TupleProviderWithProps } from '../types/provider';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Providers<T = any> = Array<
+  ProviderComponent<T> | TupleProviderWithProps<T>
+>;
+
+export function FlatProviders({
+  providers,
+  children,
+}: PropsWithChildren<{
+  providers: Providers;
+}>): ReactElement {
+  const unwrappedProviders = providers.map(unwrapTupleProvider);
+
+  const NestedProviders = unwrappedProviders.reduce(nestProviders);
+
+  return <NestedProviders>{children}</NestedProviders>;
+}

--- a/src/helpers/chain-providers.tsx
+++ b/src/helpers/chain-providers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlatProviders, Providers } from '..';
+import { FlatProviders, Providers } from '../core/flat-providers';
 import { ProviderComponent, ProviderComponentProps } from '../types/provider';
 
 export function useChainProviders() {

--- a/src/helpers/chain-providers.tsx
+++ b/src/helpers/chain-providers.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FlatProviders, Providers } from '..';
+import { ProviderComponent, ProviderComponentProps } from '../types/provider';
+
+export function useChainProviders() {
+  const providers: Providers = [];
+
+  const ChainBuilder = {
+    /**
+     * Adds a new provider with its props to the stack.
+     * The chain must end into `make()`
+     */
+    add<T>(provider: ProviderComponent<T>, props?: ProviderComponentProps<T>) {
+      providers.push(props ? [provider, props] : provider);
+      return ChainBuilder;
+    },
+    /**
+     * Must be called once at the end of the Providers Chain.
+     */
+    make() {
+      const ChainedFlatProviders: React.FunctionComponent = ({ children }) => {
+        return <FlatProviders providers={providers}>{children}</FlatProviders>;
+      };
+
+      return ChainedFlatProviders;
+    },
+  };
+
+  return ChainBuilder;
+}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,27 +1,27 @@
 import { render, screen } from '@testing-library/react';
 import React, { PropsWithChildren, ReactElement, useContext } from 'react';
-import { FlatProviders } from './';
+import { FlatProviders, useChainProviders } from './';
 import { makeProvider } from './helpers/make-provider';
 
+type TestContextValue = 'defaultValue' | 'expectedValue';
+const TestContext = React.createContext<TestContextValue>('defaultValue');
+const ContextConsumer = (): ReactElement => {
+  const testValue = useContext(TestContext);
+  return <h1>{testValue}</h1>;
+};
+
+type AdvancedContextValue = {
+  contextKey: 'defaultAdvanced' | 'expectedAdvanced';
+};
+const AdvancedTestContext = React.createContext<AdvancedContextValue>({
+  contextKey: 'defaultAdvanced',
+});
+const AdvancedConsumer = (): ReactElement => {
+  const { contextKey } = useContext(AdvancedTestContext);
+  return <h1>{contextKey}</h1>;
+};
+
 describe('react-flat-providers', (): void => {
-  type TestContextValue = 'defaultValue' | 'expectedValue';
-  const TestContext = React.createContext<TestContextValue>('defaultValue');
-  const ContextConsumer = (): ReactElement => {
-    const testValue = useContext(TestContext);
-    return <h1>{testValue}</h1>;
-  };
-
-  type AdvancedContextValue = {
-    contextKey: 'defaultAdvanced' | 'expectedAdvanced';
-  };
-  const AdvancedTestContext = React.createContext<AdvancedContextValue>({
-    contextKey: 'defaultAdvanced',
-  });
-  const AdvancedConsumer = (): ReactElement => {
-    const { contextKey } = useContext(AdvancedTestContext);
-    return <h1>{contextKey}</h1>;
-  };
-
   it('wraps a given provider with given props correctly around the consuming child-component.', async (): Promise<void> => {
     render(
       <FlatProviders
@@ -31,7 +31,7 @@ describe('react-flat-providers', (): void => {
       </FlatProviders>,
     );
 
-    expect(screen.getByText('expectedValue')).not.toBeNull();
+    expect(screen.getByText('expectedValue')).toBeTruthy();
   });
 
   it('wraps multiple providers correctly around the consuming children.', async (): Promise<void> => {
@@ -50,8 +50,8 @@ describe('react-flat-providers', (): void => {
       </FlatProviders>,
     );
 
-    expect(screen.getByText('expectedValue')).not.toBeNull();
-    expect(screen.getByText('expectedAdvanced')).not.toBeNull();
+    expect(screen.getByText('expectedValue')).toBeTruthy();
+    expect(screen.getByText('expectedAdvanced')).toBeTruthy();
   });
 
   it('renders providers built with function.', async (): Promise<void> => {
@@ -69,8 +69,8 @@ describe('react-flat-providers', (): void => {
       </FlatProviders>,
     );
 
-    expect(screen.getByText('expectedValue')).not.toBeNull();
-    expect(screen.getByText('expectedAdvanced')).not.toBeNull();
+    expect(screen.getByText('expectedValue')).toBeTruthy();
+    expect(screen.getByText('expectedAdvanced')).toBeTruthy();
   });
 
   it('allows to pass a Provider without props.', async (): Promise<void> => {
@@ -90,7 +90,7 @@ describe('react-flat-providers', (): void => {
       </FlatProviders>,
     );
 
-    expect(screen.getByText('expectedValue')).not.toBeNull();
+    expect(screen.getByText('expectedValue')).toBeTruthy();
   });
 
   it('allows passing simple components as well and renders those.', async (): Promise<void> => {
@@ -100,6 +100,25 @@ describe('react-flat-providers', (): void => {
       />,
     );
 
-    expect(screen.getByTestId('first')).not.toBeNull();
+    expect(screen.getByTestId('first')).toBeTruthy();
+  });
+
+  it('chain providers and renders context value.', async (): Promise<void> => {
+    const FlatChainProviders = useChainProviders()
+      .add(TestContext.Provider, { value: 'expectedValue' })
+      .add(AdvancedTestContext.Provider, {
+        value: { contextKey: 'expectedAdvanced' },
+      })
+      .make();
+
+    render(
+      <FlatChainProviders>
+        <ContextConsumer />
+        <AdvancedConsumer />
+      </FlatChainProviders>,
+    );
+
+    expect(screen.getByText('expectedValue')).toBeTruthy();
+    expect(screen.getByText('expectedAdvanced')).toBeTruthy();
   });
 });

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import React, { PropsWithChildren, ReactElement, useContext } from 'react';
-import { FlatProviders, useChainProviders } from './';
-import { makeProvider } from './helpers/make-provider';
+import { FlatProviders, useChainProviders, makeProvider } from './';
 
 type TestContextValue = 'defaultValue' | 'expectedValue';
 const TestContext = React.createContext<TestContextValue>('defaultValue');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,4 +21,5 @@ export function FlatProviders({
   return <NestedProviders>{children}</NestedProviders>;
 }
 
+export * from './helpers/chain-providers';
 export * from './helpers/make-provider';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,25 +1,3 @@
-import React, { PropsWithChildren, ReactElement } from 'react';
-import { nestProviders } from './aggregators/nest-providers';
-import { unwrapTupleProvider } from './aggregators/unwrap-tuple-providers';
-import { ProviderComponent, TupleProviderWithProps } from './types/provider';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Providers<T = any> = Array<
-  ProviderComponent<T> | TupleProviderWithProps<T>
->;
-
-export function FlatProviders({
-  providers,
-  children,
-}: PropsWithChildren<{
-  providers: Providers;
-}>): ReactElement {
-  const unwrappedProviders = providers.map(unwrapTupleProvider);
-
-  const NestedProviders = unwrappedProviders.reduce(nestProviders);
-
-  return <NestedProviders>{children}</NestedProviders>;
-}
-
+export * from './core/flat-providers';
 export * from './helpers/chain-providers';
 export * from './helpers/make-provider';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "esnext",
-    "lib": ["dom", "esnext"],
+    "module": "ES6",
+    "lib": ["dom", "ES6"],
     "moduleResolution": "node",
     "jsx": "react",
     "sourceMap": true,
@@ -16,7 +16,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es5",
+    "target": "ES6",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
@davelosert - as you can see, we can be congratulated with v2.0.0 release :)
I've updated stackblitz: https://stackblitz.com/edit/react-flat-providers-example

Check out this PR as it contains the long-awaited feature to chain and make providers in one go.
And also some changes to the tests and some refactoring.